### PR TITLE
Improve realtime P2P mechanism & added toggle Button Connection:

### DIFF
--- a/object/gui/chat.go
+++ b/object/gui/chat.go
@@ -38,8 +38,9 @@ const (
 
 var (
 	//go:embed ..\..\game_asset\asset\JetBrainsMonoNL-Regular.ttf
-	jetbrainsMonoTTF []byte
-	onMessageHandler func(msg string)
+	jetbrainsMonoTTF    []byte
+	onMessageHandler    func(msg string)
+	onButtonConnHandler func(isConn bool)
 )
 
 func defaultFace(size float64) text.Face {
@@ -144,6 +145,24 @@ func NewChat(initial []ChatMessage) *Chat {
 		}),
 	)
 
+	connBtnClicked := true
+	startConnButton := widget.NewButton(
+		widget.ButtonOpts.WidgetOpts(widget.WidgetOpts.MinSize(btnW, btnH)),
+		widget.ButtonOpts.Image(buttonImage),
+		widget.ButtonOpts.TextPadding(widget.Insets{Right: 15, Left: 15}),
+		widget.ButtonOpts.Text("Connect", face, &widget.ButtonTextColor{Idle: color.White}),
+		widget.ButtonOpts.ClickedHandler(func(this *widget.ButtonClickedEventArgs) {
+			if connBtnClicked {
+				this.Button.Text().Label = "Disconnect"
+				connBtnClicked = false
+			} else {
+				this.Button.Text().Label = "Connect"
+				connBtnClicked = true
+			}
+			onButtonConnHandler(connBtnClicked)
+		}),
+	)
+
 	c.bottomLayout = widget.NewContainer(
 		widget.ContainerOpts.Layout(widget.NewRowLayout(
 			widget.RowLayoutOpts.Spacing(gap),
@@ -153,6 +172,7 @@ func NewChat(initial []ChatMessage) *Chat {
 	c.bottomLayout.AddChild(c.input)
 	c.bottomLayout.AddChild(sendBtn)
 	c.bottomLayout.AddChild(toggleBtn)
+	c.bottomLayout.AddChild(startConnButton)
 
 	rootContainer := widget.NewContainer(
 		widget.ContainerOpts.Layout(widget.NewRowLayout(
@@ -256,4 +276,8 @@ func (c *Chat) AddMessage(playerID string, msg string) {
 
 func (c *Chat) RegisterMessageHandler(handler func(msg string)) {
 	onMessageHandler = handler
+}
+
+func (c *Chat) RegisterOnButtonConnHandler(handler func(isConn bool)) {
+	onButtonConnHandler = handler
 }

--- a/object/player.go
+++ b/object/player.go
@@ -24,6 +24,8 @@ type Player struct {
 	frameIndex int
 	timer      float64
 	currentDir int
+
+	isOnInput bool
 }
 
 func NewPlayer(screenWidth, screenHeight float64) *Player {
@@ -143,8 +145,11 @@ func (p *Player) Update(world *World, obstacles []*Obstacle, silentNpcs []*Silen
 	}
 	if dx == 0 && dy == 0 {
 		p.frameIndex = 3
+		//isOnInput buat trigger handler
+		p.isOnInput = false
 	} else {
 		p.frameIndex = direction*6 + p.frameIndex%6
+		p.isOnInput = true
 	}
 }
 
@@ -167,4 +172,10 @@ func (p *Player) Draw(screen *ebiten.Image, camera *Camera) {
 	op.GeoM.Translate((p.x-camera.x)*camera.zoomFactor, (p.y-camera.y)*camera.zoomFactor)
 
 	screen.DrawImage(p.image.SubImage(sourceRect).(*ebiten.Image), op)
+}
+
+func (p *Player) OnLocalPlayerInput(handler func()) {
+	if p.isOnInput {
+		handler()
+	}
 }


### PR DESCRIPTION
- Created a GUI button to start/stop P2P connection using a callback function to toggle P2P and WebSocket connections.
- Added a function that accepts a callback to handle disconnection events (e.g., when a player disconnects) — used for removing entries from the remote player map.
- Added a function that accepts a callback to send position updates when the local player moves (currently using dx & dy player) — used to real time position data sending.
- Added a function that accepts a callback triggered on the first onOpen event of the dataChannel "position" — used to initiate position sending.